### PR TITLE
update server name

### DIFF
--- a/topics/rivanna.qmd
+++ b/topics/rivanna.qmd
@@ -33,7 +33,7 @@ Find under "Clusters" in the menu. 
 You can also access the remote command line via SSH on your local computer. Just enter the following on the command line of either a PC or Mac:
 
 ```bash
-ssh -Y <userid>@hpc.rivanna.virginia.edu
+ssh -Y <userid>@rivanna.hpc.virginia.edu
 ```
 
 Replace `<userid>` with your UVA Net ID, e.g. `abc2x`. 


### PR DESCRIPTION
Server name currently has an error: hpc.rivanna.virginia.edu does not resolve, whereas rivanna.hpc.virginia.edu does resolve, consistent with https://www.rc.virginia.edu/userinfo/rivanna/login/ .